### PR TITLE
Bump jodconverter to 4.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <name>excella-pdfexporter</name>
 
   <properties>
-    <java.version>1.7</java.version>
+    <java.version>1.8</java.version>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -108,8 +108,8 @@
   	</dependency>
   	<dependency>
   		<groupId>org.jodconverter</groupId>
-  		<artifactId>jodconverter-core</artifactId>
-  		<version>4.0.0-RELEASE</version>
+  		<artifactId>jodconverter-local</artifactId>
+  		<version>4.2.2</version>
   	</dependency>
   </dependencies>
 </project>

--- a/src/main/java/org/bbreak/excella/reports/exporter/OoPdfExporter.java
+++ b/src/main/java/org/bbreak/excella/reports/exporter/OoPdfExporter.java
@@ -28,9 +28,6 @@
 package org.bbreak.excella.reports.exporter;
 
 import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -135,7 +132,7 @@ public class OoPdfExporter extends ReportBookExporter {
         }
 
         if ( !controlOfficeManager) {
-            officeManager = new DefaultOfficeManagerBuilder().setPortNumber( port).build();
+            officeManager = new DefaultOfficeManagerBuilder().setPortNumbers( port).build();
             try {
                 officeManager.start();
             } catch ( OfficeException e) {
@@ -191,17 +188,19 @@ public class OoPdfExporter extends ReportBookExporter {
      */
     private DocumentFormatRegistry createDocumentFormatRegistry( ConvertConfiguration configuration) {
 
-        SimpleDocumentFormatRegistry registry = DefaultDocumentFormatRegistry.getInstance();
+        SimpleDocumentFormatRegistry registry = ( SimpleDocumentFormatRegistry) DefaultDocumentFormatRegistry.getInstance();
 
         if ( configuration == null || configuration.getOptionsProperties().isEmpty()) {
             return registry;
         }
 
-        DocumentFormat documentFormat = registry.getFormatByExtension( "pdf");
-        Map<String, Object> optionMap = new HashMap<String, Object>( documentFormat.getStoreProperties( DocumentFamily.SPREADSHEET));
+        DocumentFormat sourceFormat = registry.getFormatByExtension( "pdf");
+        DocumentFormat modifiedFormat = DocumentFormat.builder() //
+            .from( sourceFormat) //
+            .storeProperty( DocumentFamily.SPREADSHEET, "FilterData", configuration.getOptions()) //
+            .build();
 
-        optionMap.put( "FilterData", configuration.getOptions());
-        documentFormat.setStoreProperties( DocumentFamily.SPREADSHEET, optionMap);
+        registry.addFormat( modifiedFormat);
 
         return registry;
     }


### PR DESCRIPTION
JODConverterを4.2.2にアップデートしました。

- DefaultOfficeManagerBuilderが非推奨(後方互換性のため維持されている)となりましたが、代替とするべきExternalOfficeManagerに可視性の問題があるため引き続き使用します。
    - https://github.com/sbraconnier/jodconverter/issues/121 にて報告・修正済みですが、修正を含むバージョンがリリースされていない
- JODConverter 4.1.1以降、Java 8以降が必要です。